### PR TITLE
fix(triangulate-image): update dependency and fix API changes

### DIFF
--- a/scripts/lib/triangulate-image.js
+++ b/scripts/lib/triangulate-image.js
@@ -56,355 +56,914 @@
     }({
         1: [ function(_dereq_, module, exports) {
             'use strict';
-            module.exports = {
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
+            }
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            });
+            var _extends = Object.assign || function(target) {
+                for (var i = 1; i < arguments.length; i++) {
+                    var source = arguments[i];
+                    for (var key in source) {
+                        Object.prototype.hasOwnProperty.call(source, key) && (target[key] = source[key]);
+                    }
+                }
+                return target;
+            };
+            exports.default = function(params) {
+                function getParams() {
+                    return params;
+                }
+                function getInput() {
+                    var result = _extends({}, api);
+                    return inputFn || _extends(result, inputMethods), result;
+                }
+                function getOutput() {
+                    var result = _extends({}, api);
+                    return outputFn || _extends(result, outputMethods), result;
+                }
+                function fromImage(inputParams) {
+                    return setInput(_fromImageToImageData2.default, inputParams);
+                }
+                function fromImageSync(inputParams) {
+                    return setInput(_fromImageToImageData2.default, inputParams, !0);
+                }
+                function fromImageData(inputParams) {
+                    return setInput(function(id) {
+                        return id;
+                    }, inputParams);
+                }
+                function fromImageDataSync(inputParams) {
+                    return setInput(function(id) {
+                        return id;
+                    }, inputParams, !0);
+                }
+                function toData(outputParams) {
+                    return setOutput(function(p) {
+                        return p;
+                    }, outputParams);
+                }
+                function toDataSync(outputParams) {
+                    return setOutput(function(p) {
+                        return p;
+                    }, outputParams, !0);
+                }
+                function toDataURL(outputParams) {
+                    return setOutput(_polygonsToDataURL2.default, outputParams);
+                }
+                function toDataURLSync(outputParams) {
+                    return setOutput(_polygonsToDataURL2.default, outputParams, !0);
+                }
+                function toImageData(outputParams) {
+                    return setOutput(_polygonsToImageData2.default, outputParams);
+                }
+                function toImageDataSync(outputParams) {
+                    return setOutput(_polygonsToImageData2.default, outputParams, !0);
+                }
+                function toSVG(outputParams) {
+                    return setOutput(_polygonsToSVG2.default, outputParams);
+                }
+                function toSVGSync(outputParams) {
+                    return setOutput(_polygonsToSVG2.default, outputParams, !0);
+                }
+                function setInput(fn, inputParams, isSync) {
+                    return isInputSync = !!isSync, inputFn = function() {
+                        return isInputSync ? fn(inputParams) : new Promise(function(resolve, reject) {
+                            try {
+                                var imageData = fn(inputParams);
+                                resolve(imageData);
+                            } catch (err) {
+                                reject(err);
+                            }
+                        });
+                    }, isReady() ? getResult() : getOutput();
+                }
+                function setOutput(fn, outputpParams, isSync) {
+                    return isOutputSync = !!isSync, outputFn = function(polygons, size) {
+                        return isOutputSync ? fn(polygons, size, outputpParams) : new Promise(function(resolve, reject) {
+                            try {
+                                var outputData = fn(polygons, size, outputpParams);
+                                resolve(outputData);
+                            } catch (err) {
+                                reject(err);
+                            }
+                        });
+                    }, isReady() ? getResult() : getInput();
+                }
+                function isReady() {
+                    return inputFn && outputFn;
+                }
+                function getResult() {
+                    if (isInputSync && isOutputSync) {
+                        var imageData = inputFn(params), polygonData = (0, _imageDataToPolygons2.default)(imageData, params), outputData = outputFn(polygonData, imageData);
+                        return outputData;
+                    }
+                    return new Promise(function(resolve, reject) {
+                        var imageData;
+                        makeInput().then(function(imgData) {
+                            return imageData = imgData, makePolygonsInWorker(imageData, params);
+                        }, reject).then(function(polygonData) {
+                            return makeOutput(polygonData, imageData);
+                        }, reject).then(function(outputData) {
+                            resolve(outputData);
+                        }, reject);
+                    });
+                }
+                function makeInput(inputParams) {
+                    return new Promise(function(resolve, reject) {
+                        if (isInputSync) {
+                            try {
+                                var imageData = inputFn(inputParams);
+                                resolve(imageData);
+                            } catch (err) {
+                                reject(err);
+                            }
+                        } else {
+                            inputFn(inputParams).then(resolve, reject);
+                        }
+                    });
+                }
+                function makePolygonsInWorker(imageData, params) {
+                    return new Promise(function(resolve, reject) {
+                        worker.addEventListener('message', function(event) {
+                            if (event.data && event.data.polygonJSONStr) {
+                                var polygonData = JSON.parse(event.data.polygonJSONStr);
+                                resolve(polygonData);
+                            } else {
+                                reject(event.data && event.data.err ? event.data.err : event);
+                            }
+                        }), worker.postMessage({
+                            params: params,
+                            imageData: imageData,
+                            imageDataWidth: imageData.width,
+                            imageDataHeight: imageData.height
+                        });
+                    });
+                }
+                function makeOutput(polygonData, imageData) {
+                    return new Promise(function(resolve, reject) {
+                        if (isOutputSync) {
+                            try {
+                                var outputData = outputFn(polygonData, imageData);
+                                resolve(outputData);
+                            } catch (e) {
+                                reject(e);
+                            }
+                        } else {
+                            outputFn(polygonData, imageData).then(resolve, reject);
+                        }
+                    });
+                }
+                params = (0, _sanitizeInput2.default)(params);
+                var isInputSync = !1, isOutputSync = !1, worker = (0, _webworkify2.default)(_triangulationWorker2.default), inputFn = void 0, outputFn = void 0, api = {
+                    getParams: getParams,
+                    getInput: getInput,
+                    getOutput: getOutput
+                }, inputMethods = {
+                    fromImage: fromImage,
+                    fromImageSync: fromImageSync,
+                    fromImageData: fromImageData,
+                    fromImageDataSync: fromImageDataSync
+                }, outputMethods = {
+                    toData: toData,
+                    toDataSync: toDataSync,
+                    toDataURL: toDataURL,
+                    toDataURLSync: toDataURLSync,
+                    toImageData: toImageData,
+                    toImageDataSync: toImageDataSync,
+                    toSVG: toSVG,
+                    toSVGSync: toSVGSync
+                };
+                return getInput();
+            };
+            var _sanitizeInput = _dereq_('./input/sanitizeInput'), _sanitizeInput2 = _interopRequireDefault(_sanitizeInput), _fromImageToImageData = _dereq_('./input/browser/fromImageToImageData'), _fromImageToImageData2 = _interopRequireDefault(_fromImageToImageData), _polygonsToImageData = _dereq_('./output/polygonsToImageData'), _polygonsToImageData2 = _interopRequireDefault(_polygonsToImageData), _polygonsToDataURL = _dereq_('./output/polygonsToDataURL'), _polygonsToDataURL2 = _interopRequireDefault(_polygonsToDataURL), _polygonsToSVG = _dereq_('./output/polygonsToSVG'), _polygonsToSVG2 = _interopRequireDefault(_polygonsToSVG), _imageDataToPolygons = _dereq_('./polygons/imageDataToPolygons'), _imageDataToPolygons2 = _interopRequireDefault(_imageDataToPolygons), _webworkify = _dereq_('webworkify'), _webworkify2 = _interopRequireDefault(_webworkify), _triangulationWorker = _dereq_('./workers/triangulationWorker'), _triangulationWorker2 = _interopRequireDefault(_triangulationWorker);
+            module.exports = exports.default;
+        }, {
+            './input/browser/fromImageToImageData': 4,
+            './input/sanitizeInput': 6,
+            './output/polygonsToDataURL': 7,
+            './output/polygonsToImageData': 8,
+            './output/polygonsToSVG': 9,
+            './polygons/imageDataToPolygons': 16,
+            './workers/triangulationWorker': 30,
+            webworkify: 35
+        } ],
+        2: [ function(_dereq_, module, exports) {
+            'use strict';
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
+            }
+            function copyImageDataWithCanvas(imageData) {
+                var canvas = (0, _canvasBrowserify2.default)(imageData.width, imageData.height), ctx = canvas.getContext('2d');
+                return ctx.putImageData(imageData, 0, 0), ctx.getImageData(0, 0, imageData.width, imageData.height);
+            }
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(imageData) {
+                if ((0, _isImageData2.default)(imageData)) {
+                    if ('undefined' == typeof Uint8ClampedArray) {
+                        if ('undefined' == typeof window) {
+                            throw new Error('Can\'t copy imageData in webworker without Uint8ClampedArray support.');
+                        }
+                        return copyImageDataWithCanvas(imageData);
+                    }
+                    var clampedArray = new Uint8ClampedArray(imageData.data);
+                    if ('undefined' == typeof ImageData) {
+                        return {
+                            width: imageData.width,
+                            height: imageData.height,
+                            data: clampedArray
+                        };
+                    }
+                    var result = void 0;
+                    try {
+                        result = new ImageData(clampedArray, imageData.width, imageData.height);
+                    } catch (err) {
+                        if ('undefined' == typeof window) {
+                            throw new Error('Can\'t copy imageData in webworker without proper ImageData() support.');
+                        }
+                        result = copyImageDataWithCanvas(imageData);
+                    }
+                    return result;
+                }
+                throw new Error('Given imageData object is not useable.');
+            };
+            var _canvasBrowserify = _dereq_('canvas-browserify'), _canvasBrowserify2 = _interopRequireDefault(_canvasBrowserify), _isImageData = _dereq_('../util/isImageData'), _isImageData2 = _interopRequireDefault(_isImageData);
+            module.exports = exports.default;
+        }, {
+            '../util/isImageData': 23,
+            'canvas-browserify': 31
+        } ],
+        3: [ function(_dereq_, module, exports) {
+            'use strict';
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(imageData) {
+                for (var len = imageData.data.length, brightness = void 0, i = 0; i < len; i += 4) {
+                    brightness = .34 * imageData.data[i] + .5 * imageData.data[i + 1] + .16 * imageData.data[i + 2], 
+                    imageData.data[i] = brightness, imageData.data[i + 1] = brightness, imageData.data[i + 2] = brightness;
+                }
+                return imageData;
+            }, module.exports = exports.default;
+        }, {} ],
+        4: [ function(_dereq_, module, exports) {
+            'use strict';
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
+            }
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(image) {
+                if (image instanceof HTMLImageElement) {
+                    if (!image.naturalWidth || !image.naturalHeight || image.complete === !1) {
+                        throw new Error('This this image hasn\'t finished loading: ' + image.src);
+                    }
+                    var canvas = new _canvasBrowserify2.default(image.naturalWidth, image.naturalHeight), ctx = canvas.getContext('2d');
+                    ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+                    var imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+                    return imageData.data && imageData.data.length && ('undefined' == typeof imageData.width && (imageData.width = image.naturalWidth), 
+                    'undefined' == typeof imageData.height && (imageData.height = image.naturalHeight)), 
+                    imageData;
+                }
+                throw new Error('This object does not seem to be an image.');
+            };
+            var _canvasBrowserify = _dereq_('canvas-browserify'), _canvasBrowserify2 = _interopRequireDefault(_canvasBrowserify), Image = _canvasBrowserify2.default.Image;
+            module.exports = exports.default;
+        }, {
+            'canvas-browserify': 31
+        } ],
+        5: [ function(_dereq_, module, exports) {
+            'use strict';
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = {
                 accuracy: .7,
-                blur: 40,
+                blur: 4,
                 fill: !0,
                 stroke: !0,
                 strokeWidth: .5,
                 lineJoin: 'miter',
-                vertexCount: 700
-            };
-        }, {} ],
-        2: [ function(_dereq_, module, exports) {
-            'use strict';
-            function checkParams(params) {
-                return 'object' != typeof params && (params = {}), 'number' != typeof params.accuracy || isNaN(params.accuracy) ? params.accuracy = defaultParams.accuracy : params.accuracy = clamp(params.accuracy, 0, 1), 
-                ('number' != typeof params.blur || isNaN(params.blur)) && (params.blur = defaultParams.blur), 
-                'string' != typeof params.fill && 'boolean' != typeof params.fill && (params.fill = defaultParams.fill), 
-                'string' != typeof params.stroke && 'boolean' != typeof params.stroke && (params.stroke = defaultParams.stroke), 
-                ('number' != typeof params.strokeWidth || isNaN(params.strokeWidth)) && (params.strokeWidth = defaultParams.strokeWidth), 
-                ('string' != typeof params.lineJoin || -1 === allowedLineJoins.indexOf(params.lineJoin)) && (params.lineJoin = defaultParams.lineJoin), 
-                ('number' != typeof params.vertexCount || isNaN(params.vertexCount)) && (params.vertexCount = defaultParams.vertexCount), 
-                params;
-            }
-            var clamp = _dereq_('./util/clamp.js'), defaultParams = _dereq_('./defaultParams.js'), fromImageToImageData = _dereq_('./input/fromImageToImageData.js'), polygonsToImageData = _dereq_('./output/polygonsToImageData.js'), polygonsToDataURL = _dereq_('./output/polygonsToDataURL.js'), polygonsToSVG = _dereq_('./output/polygonsToSVG.js'), fromBufferToImageData, polygonsToBuffer, polygonsToPNGStream, polygonsToJPGStream, polygonsToSVGStream, allowedLineJoins = [ 'miter', 'round', 'bevel' ];
-            module.exports = function(params, callback) {
-                function getInput() {
-                    return input;
-                }
-                function getOutput() {
-                    return output;
-                }
-                function canStart() {
-                    return inputFn && outputFn && params;
-                }
-                function getParams() {
-                    return params;
-                }
-                function go(fn) {
-                    return canStart() ? start() : fn();
-                }
-                function start() {
-                    var imageData = inputFn(), polygons = callback(imageData, params);
-                    return outputFn(polygons, imageData);
-                }
-                params = checkParams(params);
-                var inputFn, outputFn, input = {
-                    getParams: getParams
-                }, output = {
-                    getParams: getParams
-                };
-                return input.fromImageData = function(imageData) {
-                    return inputFn = function() {
-                        return imageData;
-                    }, go(getOutput);
-                }, output.toDataURL = function(dataUrlParams) {
-                    return outputFn = function(polygons, size) {
-                        return polygonsToDataURL(polygons, size, dataUrlParams);
-                    }, go(getInput);
-                }, output.toImageData = function(imageDataParams) {
-                    return outputFn = function(polygons, size) {
-                        return polygonsToImageData(polygons, size, imageDataParams);
-                    }, go(getInput);
-                }, output.toSVG = function() {
-                    return outputFn = polygonsToSVG, go(getInput);
-                }, output.toData = function() {
-                    return outputFn = function(polygons) {
-                        return polygons;
-                    }, go(getInput);
-                }, input.fromImage = function(imageEl) {
-                    return inputFn = function() {
-                        return fromImageToImageData(imageEl);
-                    }, go(getOutput);
-                }, getInput();
-            };
-        }, {
-            './defaultParams.js': 1,
-            './input/fromImageToImageData.js': 6,
-            './output/polygonsToDataURL.js': 7,
-            './output/polygonsToImageData.js': 8,
-            './output/polygonsToSVG.js': 9,
-            './util/clamp.js': 14
-        } ],
-        3: [ function(_dereq_, module, exports) {
-            'use strict';
-            var Canvas = _dereq_('canvas-browserify');
-            module.exports = function(imageData) {
-                if ('undefined' == typeof Uint8ClampedArray) {
-                    var canvas = Canvas(imageData.width, imageData.height), ctx = canvas.getContext('2d');
-                    return ctx.putImageData(imageData, 0, 0), ctx.getImageData(0, 0, imageData.width, imageData.height);
-                }
-                return {
-                    width: imageData.width,
-                    height: imageData.height,
-                    data: new Uint8ClampedArray(imageData.data)
-                };
-            };
-        }, {
-            'canvas-browserify': 18
-        } ],
-        4: [ function(_dereq_, module, exports) {
-            'use strict';
-            function detectEdges(imageData, accuracy, edgeSize, divisor) {
-                var matrix = getEdgeMatrix(edgeSize).slice(), multiplier = parseInt(10 * (accuracy || .5), 10) || 1;
-                divisor = divisor || 1;
-                var k, len, divscalar = divisor ? 1 / divisor : 0;
-                if (1 !== divscalar) {
-                    for (k = 0, len = matrix.length; k < matrix.length; k++) {
-                        matrix[k] *= divscalar;
-                    }
-                }
-                var data = imageData.data;
-                len = data.length >> 2;
-                var copy = new Uint8Array(len);
-                for (i = 0; len > i; i++) {
-                    copy[i] = data[i << 2];
-                }
-                var x, y, r, g, b, v, col, row, sx, sy, i, istep, jstep, kstep, width = 0 | imageData.width, height = 0 | imageData.height, size = Math.sqrt(matrix.length), range = .5 * size | 0;
-                for (y = 0; height > y; y += multiplier) {
-                    for (istep = y * width, x = 0; width > x; x += multiplier) {
-                        for (r = g = b = 0, row = -range; range >= row; row++) {
-                            if (sy = y + row, jstep = sy * width, kstep = (row + range) * size, sy >= 0 && height > sy) {
-                                for (col = -range; range >= col; col++) {
-                                    sx = x + col, sx >= 0 && width > sx && (v = matrix[col + range + kstep]) && (r += copy[sx + jstep] * v);
-                                }
-                            }
-                        }
-                        0 > r ? r = 0 : r > 255 && (r = 255), data[x + istep << 2] = 255 & r;
-                    }
-                }
-                return imageData;
-            }
-            function getEdgeMatrix(size) {
-                var i, matrix = [], side = 2 * size + 1, len = side * side, center = .5 * len | 0;
-                for (i = 0; len > i; i++) {
-                    matrix[i] = i === center ? -len + 1 : 1;
-                }
-                return matrix;
-            }
-            module.exports = detectEdges;
-        }, {} ],
-        5: [ function(_dereq_, module, exports) {
-            'use strict';
-            function greyscale(imageData) {
-                for (var len = imageData.data.length, data = imageData.data, brightness = void 0, i = 0; len > i; i += 4) {
-                    brightness = .34 * data[i] + .5 * data[i + 1] + .16 * data[i + 2], data[i] = brightness, 
-                    data[i + 1] = brightness, data[i + 2] = brightness;
-                }
-                return imageData.data = data, imageData;
-            }
-            module.exports = greyscale;
+                vertexCount: 700,
+                threshold: 50,
+                transparentColor: !1
+            }, module.exports = exports.default;
         }, {} ],
         6: [ function(_dereq_, module, exports) {
             'use strict';
-            var Canvas = _dereq_('canvas-browserify'), Image = Canvas.Image;
-            module.exports = function(image) {
-                if (image instanceof HTMLImageElement) {
-                    if (0 === image.naturalWidth || 0 === image.naturalHeight || image.complete === !1) {
-                        throw new Error('This this image hasn\'t finished loading: ' + image.src);
-                    }
-                    var canvas = new Canvas(image.naturalWidth, image.naturalHeight), ctx = canvas.getContext('2d');
-                    return ctx.drawImage(image, 0, 0, canvas.width, canvas.height), ctx.getImageData(0, 0, canvas.width, canvas.height);
-                }
-                throw new Error('This object does not seem to be an image.');
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
+            }
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            });
+            var _typeof = 'function' == typeof Symbol && 'symbol' == typeof Symbol.iterator ? function(obj) {
+                return typeof obj;
+            } : function(obj) {
+                return obj && 'function' == typeof Symbol && obj.constructor === Symbol ? 'symbol' : typeof obj;
             };
+            exports.default = function(params) {
+                return params = (0, _clone2.default)(params), 'object' !== ('undefined' == typeof params ? 'undefined' : _typeof(params)) && (params = {}), 
+                'number' != typeof params.accuracy || isNaN(params.accuracy) ? params.accuracy = _defaultParams2.default.accuracy : params.accuracy = (0, 
+                _clamp2.default)(params.accuracy, 0, 1), ('number' != typeof params.blur || isNaN(params.blur)) && (params.blur = _defaultParams2.default.blur), 
+                params.blur <= 0 && (params.blur = 1), 'string' != typeof params.fill && 'boolean' != typeof params.fill && (params.fill = _defaultParams2.default.fill), 
+                'string' != typeof params.stroke && 'boolean' != typeof params.stroke && (params.stroke = _defaultParams2.default.stroke), 
+                ('number' != typeof params.strokeWidth || isNaN(params.strokeWidth)) && (params.strokeWidth = _defaultParams2.default.strokeWidth), 
+                'number' != typeof params.threshold || isNaN(params.threshold) ? params.threshold = _defaultParams2.default.threshold : params.threshold = (0, 
+                _clamp2.default)(params.threshold, 1, 100), 'string' == typeof params.lineJoin && allowedLineJoins.indexOf(params.lineJoin) !== -1 || (params.lineJoin = _defaultParams2.default.lineJoin), 
+                params.gradients && params.fill ? params.gradients = !0 : params.gradients = !1, 
+                params.gradients && (('number' != typeof params.gradientStops || isNaN(params.gradientStops) || params.gradientStops < 2) && (params.gradientStops = 2), 
+                params.gradientStops = Math.round(params.gradientStops)), ('number' != typeof params.vertexCount || isNaN(params.vertexCount)) && (params.vertexCount = _defaultParams2.default.vertexCount), 
+                params.vertexCount <= 0 && (params.vertexCount = 1), 'string' != typeof params.transparentColor && 'boolean' != typeof params.transparentColor && (params.transparentColor = _defaultParams2.default.transparentColor), 
+                typeof params.transparentColor === !0 && (params.transparentColor = !1), 'string' == typeof params.transparentColor && (params.transparentColor = (0, 
+                _toColor2.default)(params.transparentColor)), params;
+            };
+            var _clamp = _dereq_('../util/clamp'), _clamp2 = _interopRequireDefault(_clamp), _clone = _dereq_('../util/clone'), _clone2 = _interopRequireDefault(_clone), _toColor = _dereq_('../util/toColor'), _toColor2 = _interopRequireDefault(_toColor), _defaultParams = _dereq_('./defaultParams'), _defaultParams2 = _interopRequireDefault(_defaultParams), allowedLineJoins = [ 'miter', 'round', 'bevel' ];
+            module.exports = exports.default;
         }, {
-            'canvas-browserify': 18
+            '../util/clamp': 17,
+            '../util/clone': 18,
+            '../util/toColor': 28,
+            './defaultParams': 5
         } ],
         7: [ function(_dereq_, module, exports) {
             'use strict';
-            var Canvas = _dereq_('canvas-browserify'), drawPolygonsOnContext = _dereq_('../util/drawPolygonsOnContext.js');
-            module.exports = function(polygons, size, options) {
-                var dpr = options && options.dpr ? options.dpr : 1, backgroundColor = options && options.backgroundColor ? options.backgroundColor : !1, canvas = new Canvas(size.width * dpr, size.height * dpr), ctx = canvas.getContext('2d');
-                return backgroundColor && (ctx.fillStyle = backgroundColor, ctx.fillRect(0, 0, size.width * dpr, size.height * dpr), 
-                ctx.fillStyle = 'transparent'), drawPolygonsOnContext(ctx, polygons, size, dpr), 
-                canvas.toDataURL();
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
+            }
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(polygons, size, options) {
+                var dpr = options && options.dpr ? options.dpr : 1, canvasData = (0, _makeCanvasAndContext2.default)(size, options, dpr);
+                return (0, _drawPolygonsOnContext2.default)(canvasData.ctx, polygons, size, dpr), 
+                canvasData.canvas.toDataURL();
             };
+            var _makeCanvasAndContext = _dereq_('../util/makeCanvasAndContext'), _makeCanvasAndContext2 = _interopRequireDefault(_makeCanvasAndContext), _drawPolygonsOnContext = _dereq_('../util/drawPolygonsOnContext'), _drawPolygonsOnContext2 = _interopRequireDefault(_drawPolygonsOnContext);
+            module.exports = exports.default;
         }, {
-            '../util/drawPolygonsOnContext.js': 15,
-            'canvas-browserify': 18
+            '../util/drawPolygonsOnContext': 20,
+            '../util/makeCanvasAndContext': 26
         } ],
         8: [ function(_dereq_, module, exports) {
             'use strict';
-            var Canvas = _dereq_('canvas-browserify'), drawPolygonsOnContext = _dereq_('../util/drawPolygonsOnContext.js');
-            module.exports = function(polygons, size, options) {
-                var dpr = options && options.dpr ? options.dpr : 1, backgroundColor = options && options.backgroundColor ? options.backgroundColor : !1, canvas = new Canvas(size.width * dpr, size.height * dpr), ctx = canvas.getContext('2d');
-                return backgroundColor && (ctx.fillStyle = backgroundColor, ctx.fillRect(0, 0, size.width * dpr, size.height * dpr), 
-                ctx.fillStyle = 'transparent'), drawPolygonsOnContext(ctx, polygons, size, dpr), 
-                ctx.getImageData(0, 0, size.width * dpr, size.height * dpr);
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
+            }
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(polygons, size, options) {
+                var dpr = options && options.dpr ? options.dpr : 1, ctx = (0, _makeCanvasAndContext2.default)(size, options, dpr, !0).ctx;
+                return (0, _drawPolygonsOnContext2.default)(ctx, polygons, size, dpr), ctx.getImageData(0, 0, size.width * dpr, size.height * dpr);
             };
+            var _makeCanvasAndContext = _dereq_('../util/makeCanvasAndContext'), _makeCanvasAndContext2 = _interopRequireDefault(_makeCanvasAndContext), _drawPolygonsOnContext = _dereq_('../util/drawPolygonsOnContext'), _drawPolygonsOnContext2 = _interopRequireDefault(_drawPolygonsOnContext);
+            module.exports = exports.default;
         }, {
-            '../util/drawPolygonsOnContext.js': 15,
-            'canvas-browserify': 18
+            '../util/drawPolygonsOnContext': 20,
+            '../util/makeCanvasAndContext': 26
         } ],
         9: [ function(_dereq_, module, exports) {
             'use strict';
-            module.exports = function(polygons, size) {
-                var svg = '<?xml version="1.0" standalone="yes"?>\n<svg width="' + size.width + '" height="' + size.height + '" xmlns="http://www.w3.org/2000/svg" version="1.1" >\n	';
-                return polygons.forEach(function(polygon, index) {
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
+            }
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(polygons, size) {
+                var defStr = '';
+                polygons.length && polygons[0].gradient && (defStr = '<defs>');
+                var polygonStr = '';
+                polygons.forEach(function(polygon, index) {
                     var a = polygon.a, b = polygon.b, c = polygon.c;
-                    svg += '<polygon points="' + a.x + ',' + a.y + ' ' + b.x + ',' + b.y + ' ' + c.x + ',' + c.y + '"', 
-                    svg += polygon.fill ? ' fill="' + polygon.fill + '"' : ' fill="transparent"', polygon.strokeColor && (svg += ' stroke="' + polygon.strokeColor + '" stroke-width="' + polygon.strokeWidth + '" stroke-linejoin="' + polygon.lineJoin + '"'), 
-                    svg += '/>\n	';
-                }), svg += '\n</svg>';
+                    polygonStr += '<polygon points="' + a.x + ',' + a.y + ' ' + b.x + ',' + b.y + ' ' + c.x + ',' + c.y + '"', 
+                    polygon.gradient ? !function() {
+                        var bb = polygon.boundingBox, x1 = ((polygon.gradient.x1 - bb.x) / bb.width * 100).toFixed(3), y1 = ((polygon.gradient.y1 - bb.y) / bb.height * 100).toFixed(3), x2 = ((polygon.gradient.x2 - bb.x) / bb.width * 100).toFixed(3), y2 = ((polygon.gradient.y2 - bb.y) / bb.height * 100).toFixed(3);
+                        defStr += '\n\t<linearGradient id="gradient-' + index + '" x1="' + x1 + '%" y1="' + y1 + '%" x2="' + x2 + '%" y2="' + y2 + '%">';
+                        var lastColorIndex = polygon.gradient.colors.length - 1;
+                        polygon.gradient.colors.forEach(function(color, index) {
+                            var rgb = (0, _toRGBA2.default)(color), offset = (index / lastColorIndex * 100).toFixed(3);
+                            defStr += '\n\t\t\t\t\t<stop offset="' + offset + '%" stop-color="' + rgb + '"/>\n\t\t\t\t';
+                        }), defStr += '</linearGradient>', polygonStr += ' fill="url(#gradient-' + index + ')"', 
+                        polygon.strokeWidth > 0 && (polygonStr += ' stroke="url(#gradient-' + index + ')" stroke-width="' + polygon.strokeWidth + '" stroke-linejoin="' + polygon.lineJoin + '"');
+                    }() : (polygonStr += polygon.fill ? ' fill="' + polygon.fill + '"' : ' fill="transparent"', 
+                    polygon.strokeColor && (polygonStr += ' stroke="' + polygon.strokeColor + '" stroke-width="' + polygon.strokeWidth + '" stroke-linejoin="' + polygon.lineJoin + '"')), 
+                    polygonStr += '/>\n\t';
+                }), defStr.length && (defStr += '\n\t\t</defs>');
+                var svg = '<?xml version="1.0" standalone="yes"?>\n<svg width="' + size.width + '" height="' + size.height + '" xmlns="http://www.w3.org/2000/svg" version="1.1" >\n\t' + defStr + '\n\t' + polygonStr + '\n</svg>';
+                return svg;
             };
-        }, {} ],
+            var _toRGBA = _dereq_('../util/toRGBA'), _toRGBA2 = _interopRequireDefault(_toRGBA);
+            module.exports = exports.default;
+        }, {
+            '../util/toRGBA': 29
+        } ],
         10: [ function(_dereq_, module, exports) {
             'use strict';
-            function addColorToPolygons(polygons, colorData, params) {
-                var pixelIndex = 0, polygonCenterX = void 0, polygonCenterY = void 0, fill = params.fill, fillColor = 'string' == typeof fill ? params.fill : !1, stroke = params.stroke, strokeColor = 'string' == typeof stroke ? params.stroke : !1, strokeWidth = params.strokeWidth, lineJoin = params.lineJoin, r = void 0, g = void 0, b = void 0;
-                return polygons.forEach(function(polygon, index) {
-                    polygonCenterX = .33333 * (polygon.a.x + polygon.b.x + polygon.c.x), polygonCenterY = .33333 * (polygon.a.y + polygon.b.y + polygon.c.y), 
-                    pixelIndex = (0 | polygonCenterX) + (0 | polygonCenterY) * colorData.width << 2, 
-                    r = colorData.data[pixelIndex], g = colorData.data[pixelIndex + 1], b = colorData.data[pixelIndex + 2], 
-                    fill && (polygon.fill = fillColor || 'rgb(' + r + ', ' + g + ', ' + b + ')'), stroke && (strokeColor ? polygon.strokeColor = strokeColor : polygon.strokeColor = 'rgb(' + r + ', ' + g + ', ' + b + ')', 
-                    polygon.strokeWidth = strokeWidth, polygon.lineJoin = lineJoin);
-                }), polygons;
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
             }
-            module.exports = addColorToPolygons;
-        }, {} ],
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(polygons, colorData, params) {
+                return polygons.forEach(function(polygon) {
+                    polygon.boundingBox = (0, _getBoundingBox2.default)([ polygon.a, polygon.b, polygon.c ]);
+                }), polygons.filter(function(polygon) {
+                    return polygon.boundingBox.width > 0 && polygon.boundingBox.height > 0;
+                });
+            };
+            var _getBoundingBox = _dereq_('../util/getBoundingBox'), _getBoundingBox2 = _interopRequireDefault(_getBoundingBox);
+            module.exports = exports.default;
+        }, {
+            '../util/getBoundingBox': 21
+        } ],
         11: [ function(_dereq_, module, exports) {
             'use strict';
-            function getEdgePoints(imageData, sensitivity, accuracy) {
-                var x, y, row, col, sx, sy, step, sum, total, multiplier = parseInt(10 * (accuracy || .1), 10) || 1, edgeDetectValue = sensitivity, width = imageData.width, height = imageData.height, data = imageData.data, points = [];
-                for (y = 0; height > y; y += multiplier) {
-                    for (x = 0; width > x; x += multiplier) {
-                        for (sum = total = 0, row = -1; 1 >= row; row++) {
-                            if (sy = y + row, step = sy * width, sy >= 0 && height > sy) {
-                                for (col = -1; 1 >= col; col++) {
-                                    sx = x + col, sx >= 0 && width > sx && (sum += data[sx + step << 2], total++);
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
+            }
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(polygons, colorData, params) {
+                var fill = params.fill, stroke = params.stroke, strokeWidth = params.strokeWidth, lineJoin = params.lineJoin, transparentColor = params.transparentColor, fillColor = 'string' == typeof fill && fill, strokeColor = 'string' == typeof stroke && stroke, getColor = function(color, override) {
+                    var t = (0, _isTransparent2.default)(color) && transparentColor, c = t ? transparentColor : color;
+                    return override && !t ? override : (0, _toRGBA2.default)(c);
+                };
+                return polygons.forEach(function(polygon, index) {
+                    var color = (0, _getColorByPos2.default)((0, _polygonCenter2.default)(polygon), colorData);
+                    fill && (polygon.fill = getColor(color, fillColor)), stroke && (polygon.strokeColor = getColor(color, strokeColor), 
+                    polygon.strokeWidth = strokeWidth, polygon.lineJoin = lineJoin);
+                }), polygons;
+            };
+            var _getColorByPos = _dereq_('../util/getColorByPos'), _getColorByPos2 = _interopRequireDefault(_getColorByPos), _polygonCenter = _dereq_('../util/polygonCenter'), _polygonCenter2 = _interopRequireDefault(_polygonCenter), _isTransparent = _dereq_('../util/isTransparent'), _isTransparent2 = _interopRequireDefault(_isTransparent), _toRGBA = _dereq_('../util/toRGBA'), _toRGBA2 = _interopRequireDefault(_toRGBA);
+            module.exports = exports.default;
+        }, {
+            '../util/getColorByPos': 22,
+            '../util/isTransparent': 24,
+            '../util/polygonCenter': 27,
+            '../util/toRGBA': 29
+        } ],
+        12: [ function(_dereq_, module, exports) {
+            'use strict';
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
+            }
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(polygons, colorData, params) {
+                return polygons.forEach(function(polygon, polygonIndex) {
+                    var data = {};
+                    'abc'.split('').forEach(function(key) {
+                        var color = (0, _getColorByPos2.default)(polygon[key], colorData, params.transparentColor);
+                        data[key] = {
+                            key: key,
+                            color: color,
+                            x: polygon[key].x,
+                            y: polygon[key].y
+                        }, data[key].luminance = (0, _luminance2.default)(data[key].color);
+                        var otherKeys = 'abc'.replace(key, '').split('');
+                        data[key].median = {
+                            x: (polygon[otherKeys[0]].x + polygon[otherKeys[1]].x) / 2,
+                            y: (polygon[otherKeys[0]].y + polygon[otherKeys[1]].y) / 2
+                        }, data[key].medianColor = (0, _getColorByPos2.default)(data[key].median, colorData, params.transparentColor), 
+                        data[key].medianLuminance = (0, _luminance2.default)(data[key].medianColor);
+                    });
+                    for (var pointsByDeltaInLuminance = [ data.a, data.b, data.c ].sort(function(u, v) {
+                        return Math.abs(u.luminance - u.medianLuminance) - Math.abs(v.luminance - v.medianLuminance);
+                    }), pointWithMostDeltaInLuminance = pointsByDeltaInLuminance[0], startPoint = pointsByDeltaInLuminance[0], endPoint = pointWithMostDeltaInLuminance.median, gradienStopPositions = [ startPoint ], startToEndDistance = (0, 
+                    _distance2.default)(startPoint, endPoint), i = 1, len = params.gradientStops - 2; i < len; i++) {
+                        var pointDistance = i * (startToEndDistance / params.gradientStops), pointPercent = pointDistance / startToEndDistance, point = {
+                            x: startPoint.x + pointPercent * (endPoint.x - startPoint.x),
+                            y: startPoint.y + pointPercent * (endPoint.y - startPoint.y)
+                        };
+                        gradienStopPositions.push(point);
+                    }
+                    gradienStopPositions.push(endPoint), polygon.gradient = {
+                        x1: pointWithMostDeltaInLuminance.x,
+                        y1: pointWithMostDeltaInLuminance.y,
+                        x2: pointWithMostDeltaInLuminance.median.x,
+                        y2: pointWithMostDeltaInLuminance.median.y,
+                        colors: gradienStopPositions.map(function(pos) {
+                            return (0, _getColorByPos2.default)(pos, colorData, params.transparentColor);
+                        })
+                    }, params.stroke && (polygon.strokeWidth = params.strokeWidth, polygon.lineJoin = params.lineJoin), 
+                    data = null;
+                }), polygons;
+            };
+            var _luminance = _dereq_('../util/luminance'), _luminance2 = _interopRequireDefault(_luminance), _distance = _dereq_('../util/distance'), _distance2 = _interopRequireDefault(_distance), _getColorByPos = _dereq_('../util/getColorByPos'), _getColorByPos2 = _interopRequireDefault(_getColorByPos);
+            module.exports = exports.default;
+        }, {
+            '../util/distance': 19,
+            '../util/getColorByPos': 22,
+            '../util/luminance': 25
+        } ],
+        13: [ function(_dereq_, module, exports) {
+            'use strict';
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
+            }
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(polygons, colorData) {
+                return polygons.filter(function(polygon) {
+                    var color = (0, _getColorByPos2.default)((0, _polygonCenter2.default)(polygon), colorData);
+                    return !(0, _isTransparent2.default)(color);
+                });
+            };
+            var _getColorByPos = _dereq_('../util/getColorByPos'), _getColorByPos2 = _interopRequireDefault(_getColorByPos), _polygonCenter = _dereq_('../util/polygonCenter'), _polygonCenter2 = _interopRequireDefault(_polygonCenter), _isTransparent = _dereq_('../util/isTransparent'), _isTransparent2 = _interopRequireDefault(_isTransparent);
+            module.exports = exports.default;
+        }, {
+            '../util/getColorByPos': 22,
+            '../util/isTransparent': 24,
+            '../util/polygonCenter': 27
+        } ],
+        14: [ function(_dereq_, module, exports) {
+            'use strict';
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(imageData, threshold) {
+                var x, y, row, col, sx, sy, step, sum, total, multiplier = 2, width = imageData.width, height = imageData.height, data = imageData.data, points = [];
+                for (y = 0; y < height; y += multiplier) {
+                    for (x = 0; x < width; x += multiplier) {
+                        for (sum = total = 0, row = -1; row <= 1; row++) {
+                            if (sy = y + row, step = sy * width, sy >= 0 && sy < height) {
+                                for (col = -1; col <= 1; col++) {
+                                    sx = x + col, sx >= 0 && sx < width && (sum += data[sx + step << 2], total++);
                                 }
                             }
                         }
-                        total && (sum /= total), sum > edgeDetectValue && points.push({
+                        total && (sum /= total), sum > threshold && points.push({
                             x: x,
                             y: y
                         });
                     }
                 }
                 return points;
-            }
-            module.exports = getEdgePoints;
-        }, {} ],
-        12: [ function(_dereq_, module, exports) {
-            'use strict';
-            function sortByArea(a, b) {
-                return a.x * a.y - b.y * b.x;
-            }
-            function getVerticesFromPoints(points, maxPointCount, accuracy, width, height) {
-                var result = [], sidePointCount = 2 * Math.ceil(width / (100 - accuracy)) + 2 * Math.ceil(height / (100 - accuracy)) + 2, pointCount = Math.max(points.length, maxPointCount), randomPointCount = clamp(pointCount - sidePointCount, 0, maxPointCount - sidePointCount), increment = pointCount / randomPointCount, i = 0, x = 0, y = 0, len = 0;
-                for (points.sort(sortByArea), i = 0, len = pointCount; len > i; i += increment) {
-                    result.push({
-                        x: points[~~i].x,
-                        y: points[~~i].y
-                    });
-                }
-                for (x = 0; width > x; x += 100 - accuracy) {
-                    result.push({
-                        x: ~~x,
-                        y: 0
-                    }), result.push({
-                        x: ~~x,
-                        y: height
-                    });
-                }
-                for (y = 0; height > y; y += 100 - accuracy) {
-                    result.push({
-                        x: 0,
-                        y: ~~y
-                    }), result.push({
-                        x: width,
-                        y: ~~y
-                    });
-                }
-                return result.push({
-                    x: 0,
-                    y: height
-                }), result.push({
-                    x: width,
-                    y: height
-                }), points = null, result;
-            }
-            var clamp = _dereq_('../util/clamp.js');
-            module.exports = getVerticesFromPoints;
-        }, {
-            '../util/clamp.js': 14
-        } ],
-        13: [ function(_dereq_, module, exports) {
-            'use strict';
-            var stackBlur = _dereq_('stackblur-canvas'), delaunay = _dereq_('delaunay-fast'), isImageData = _dereq_('../util/isImageData.js'), copyImageData = _dereq_('../imagedata/copyImageData.js'), greyscale = _dereq_('../imagedata/greyscale'), detectEdges = _dereq_('../imagedata/detectEdges'), getEdgePoints = _dereq_('./getEdgePoints.js'), getVerticesFromPoints = _dereq_('./getVerticesFromPoints.js'), addColorToPolygons = _dereq_('./addColorToPolygons.js');
-            module.exports = function(imageData, params) {
-                if (isImageData(imageData)) {
-                    var imageSize = {
-                        width: imageData.width,
-                        height: imageData.height
-                    }, tmpImageData = copyImageData(imageData), colorImageData = copyImageData(imageData), blurredImageData = stackBlur.imageDataRGBA(tmpImageData, 0, 0, imageSize.width, imageSize.height, params.blur), greyscaleImageData = greyscale(blurredImageData), edgesImageData = detectEdges(greyscaleImageData), edgePoints = getEdgePoints(edgesImageData, 50, params.accuracy), edgeVertices = getVerticesFromPoints(edgePoints, params.vertexCount, params.accuracy, imageSize.width, imageSize.height), polygons = delaunay.triangulate(edgeVertices);
-                    return addColorToPolygons(polygons, colorImageData, params);
-                }
-                throw new Error('Can\'t work with the imageData provided. It seems to be corrupt');
-            };
-        }, {
-            '../imagedata/copyImageData.js': 3,
-            '../imagedata/detectEdges': 4,
-            '../imagedata/greyscale': 5,
-            '../util/isImageData.js': 16,
-            './addColorToPolygons.js': 10,
-            './getEdgePoints.js': 11,
-            './getVerticesFromPoints.js': 12,
-            'delaunay-fast': 19,
-            'stackblur-canvas': 20
-        } ],
-        14: [ function(_dereq_, module, exports) {
-            'use strict';
-            function clamp(value, min, max) {
-                return min > value ? min : value > max ? max : value;
-            }
-            module.exports = clamp;
+            }, module.exports = exports.default;
         }, {} ],
         15: [ function(_dereq_, module, exports) {
             'use strict';
-            module.exports = function(ctx, polygons, size, dpr) {
-                return dpr = dpr || 1, polygons.forEach(function(polygon, index) {
-                    ctx.beginPath(), ctx.moveTo(polygon.a.x * dpr, polygon.a.y * dpr), ctx.lineTo(polygon.b.x * dpr, polygon.b.y * dpr), 
-                    ctx.lineTo(polygon.c.x * dpr, polygon.c.y * dpr), ctx.lineTo(polygon.a.x * dpr, polygon.a.y * dpr), 
-                    polygon.fill && (ctx.fillStyle = polygon.fill, ctx.fill()), polygon.strokeColor && (ctx.strokeStyle = polygon.strokeColor, 
-                    ctx.lineWidth = polygon.strokeWidth * dpr, ctx.lineJoin = polygon.lineJoin, ctx.stroke()), 
-                    ctx.closePath();
-                }), ctx;
-            };
-        }, {} ],
-        16: [ function(_dereq_, module, exports) {
-            'use strict';
-            module.exports = function(imageData) {
-                return imageData && 'number' == typeof imageData.width && 'number' == typeof imageData.height && imageData.data && 'number' == typeof imageData.data.length;
-            };
-        }, {} ],
-        17: [ function(_dereq_, module, exports) {
-            'use strict';
-            function triangulate(params) {
-                return getInterfaceObj(params, imageDataToPolygons);
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
+            }
+            function addVertex(x, y, hash) {
+                var resultKey = x + '|' + y;
+                hash[resultKey] || (hash[resultKey] = {
+                    x: x,
+                    y: y
+                }), resultKey = null;
             }
             Object.defineProperty(exports, '__esModule', {
                 value: !0
-            }), exports['default'] = triangulate;
-            var getInterfaceObj = _dereq_('./getInterfaceObj'), imageDataToPolygons = _dereq_('./polygons/imageDataToPolygons.js');
-            module.exports = exports['default'];
+            }), exports.default = function(points, maxPointCount, accuracy, width, height) {
+                var resultHash = {}, gridPointCount = Math.max(~~(maxPointCount * (1 - accuracy)), 5), gridColumns = Math.round(Math.sqrt(gridPointCount)), gridRows = Math.round(Math.ceil(gridPointCount / gridColumns)), xIncrement = ~~(width / gridColumns), yIncrement = ~~(height / gridRows), rowIndex = 0, startX = 0, x = 0, y = 0;
+                for (y = 0; y < height; y += yIncrement) {
+                    for (rowIndex++, startX = rowIndex % 2 === 0 ? ~~(xIncrement / 2) : 0, x = startX; x < width; x += xIncrement) {
+                        x < width && y < height && addVertex(~~(x + Math.cos(y) * yIncrement), ~~(y + Math.sin(x) * xIncrement), resultHash);
+                    }
+                }
+                addVertex(0, 0, resultHash), addVertex(width - 1, 0, resultHash), addVertex(width - 1, height - 1, resultHash), 
+                addVertex(0, height - 1, resultHash);
+                var remainingPointCount = maxPointCount - Object.keys(resultHash).length, edgePointCount = points.length, increment = ~~(edgePointCount / remainingPointCount);
+                if (maxPointCount > 0 && increment > 0) {
+                    var i = 0;
+                    for (i = 0; i < edgePointCount; i += increment) {
+                        addVertex(points[i].x, points[i].y, resultHash);
+                    }
+                }
+                return points = null, Object.keys(resultHash).map(function(key) {
+                    return resultHash[key];
+                });
+            };
+            var _clamp = _dereq_('../util/clamp'), _clamp2 = _interopRequireDefault(_clamp);
+            module.exports = exports.default;
         }, {
-            './getInterfaceObj': 2,
-            './polygons/imageDataToPolygons.js': 13
+            '../util/clamp': 17
         } ],
+        16: [ function(_dereq_, module, exports) {
+            'use strict';
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
+            }
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(imageData, params) {
+                if ((0, _isImageData2.default)(imageData)) {
+                    var imageSize = {
+                        width: imageData.width,
+                        height: imageData.height
+                    }, tmpImageData = (0, _copyImageData2.default)(imageData), colorImageData = (0, 
+                    _copyImageData2.default)(imageData), blurredImageData = (0, _stackblurCanvas.imageDataRGBA)(tmpImageData, 0, 0, imageSize.width, imageSize.height, params.blur), greyscaleImageData = (0, 
+                    _greyscale2.default)(blurredImageData), edgesImageData = (0, _sobel2.default)(greyscaleImageData).toImageData(), edgePoints = (0, 
+                    _getEdgePoints2.default)(edgesImageData, params.threshold), edgeVertices = (0, _getVerticesFromPoints2.default)(edgePoints, params.vertexCount, params.accuracy, imageSize.width, imageSize.height), polygons = (0, 
+                    _delaunayFast.triangulate)(edgeVertices);
+                    return polygons = (0, _addBoundingBoxesToPolygons2.default)(polygons), params.transparentColor || (polygons = (0, 
+                    _filterTransparentPolygons2.default)(polygons, colorImageData)), polygons = params.fill === !0 && params.gradients === !0 ? (0, 
+                    _addGradientsToPolygons2.default)(polygons, colorImageData, params) : (0, _addColorToPolygons2.default)(polygons, colorImageData, params);
+                }
+                throw new Error('Can\'t work with the imageData provided. It seems to be corrupt.');
+            };
+            var _stackblurCanvas = _dereq_('stackblur-canvas'), _delaunayFast = _dereq_('delaunay-fast'), _sobel = _dereq_('sobel'), _sobel2 = _interopRequireDefault(_sobel), _isImageData = _dereq_('../util/isImageData'), _isImageData2 = _interopRequireDefault(_isImageData), _copyImageData = _dereq_('../imagedata/copyImageData'), _copyImageData2 = _interopRequireDefault(_copyImageData), _greyscale = _dereq_('../imagedata/greyscale'), _greyscale2 = _interopRequireDefault(_greyscale), _getEdgePoints = _dereq_('./getEdgePoints'), _getEdgePoints2 = _interopRequireDefault(_getEdgePoints), _getVerticesFromPoints = _dereq_('./getVerticesFromPoints'), _getVerticesFromPoints2 = _interopRequireDefault(_getVerticesFromPoints), _addBoundingBoxesToPolygons = _dereq_('./addBoundingBoxesToPolygons'), _addBoundingBoxesToPolygons2 = _interopRequireDefault(_addBoundingBoxesToPolygons), _addColorToPolygons = _dereq_('./addColorToPolygons'), _addColorToPolygons2 = _interopRequireDefault(_addColorToPolygons), _addGradientsToPolygons = _dereq_('./addGradientsToPolygons'), _addGradientsToPolygons2 = _interopRequireDefault(_addGradientsToPolygons), _filterTransparentPolygons = _dereq_('./filterTransparentPolygons'), _filterTransparentPolygons2 = _interopRequireDefault(_filterTransparentPolygons);
+            module.exports = exports.default;
+        }, {
+            '../imagedata/copyImageData': 2,
+            '../imagedata/greyscale': 3,
+            '../util/isImageData': 23,
+            './addBoundingBoxesToPolygons': 10,
+            './addColorToPolygons': 11,
+            './addGradientsToPolygons': 12,
+            './filterTransparentPolygons': 13,
+            './getEdgePoints': 14,
+            './getVerticesFromPoints': 15,
+            'delaunay-fast': 32,
+            sobel: 33,
+            'stackblur-canvas': 34
+        } ],
+        17: [ function(_dereq_, module, exports) {
+            'use strict';
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(value, min, max) {
+                return value < min ? min : value > max ? max : value;
+            }, module.exports = exports.default;
+        }, {} ],
         18: [ function(_dereq_, module, exports) {
+            'use strict';
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(obj) {
+                var result = !1;
+                if ('undefined' != typeof obj) {
+                    try {
+                        result = JSON.parse(JSON.stringify(obj));
+                    } catch (e) {}
+                }
+                return result;
+            }, module.exports = exports.default;
+        }, {} ],
+        19: [ function(_dereq_, module, exports) {
+            'use strict';
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(a, b) {
+                var dx = b.x - a.x, dy = b.y - a.y;
+                return Math.sqrt(dx * dx + dy * dy);
+            }, module.exports = exports.default;
+        }, {} ],
+        20: [ function(_dereq_, module, exports) {
+            'use strict';
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
+            }
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(ctx, polygons, size, dpr) {
+                return dpr = dpr || 1, polygons.forEach(function(polygon, index) {
+                    ctx.beginPath(), ctx.moveTo(polygon.a.x * dpr, polygon.a.y * dpr), ctx.lineTo(polygon.b.x * dpr, polygon.b.y * dpr), 
+                    ctx.lineTo(polygon.c.x * dpr, polygon.c.y * dpr), ctx.lineTo(polygon.a.x * dpr, polygon.a.y * dpr), 
+                    polygon.gradient ? !function() {
+                        var gradient = ctx.createLinearGradient(polygon.gradient.x1 * dpr, polygon.gradient.y1 * dpr, polygon.gradient.x2 * dpr, polygon.gradient.y2 * dpr), lastColorIndex = polygon.gradient.colors.length - 1;
+                        polygon.gradient.colors.forEach(function(color, index) {
+                            var rgb = (0, _toRGBA2.default)(color);
+                            gradient.addColorStop(index / lastColorIndex, rgb);
+                        }), ctx.fillStyle = gradient, ctx.fill(), polygon.strokeWidth > 0 && (ctx.strokeStyle = gradient, 
+                        ctx.lineWidth = polygon.strokeWidth * dpr, ctx.lineJoin = polygon.lineJoin, ctx.stroke());
+                    }() : (polygon.fill && (ctx.fillStyle = polygon.fill, ctx.fill()), polygon.strokeColor && (ctx.strokeStyle = polygon.strokeColor, 
+                    ctx.lineWidth = polygon.strokeWidth * dpr, ctx.lineJoin = polygon.lineJoin, ctx.stroke())), 
+                    ctx.closePath();
+                }), ctx;
+            };
+            var _toRGBA = _dereq_('./toRGBA'), _toRGBA2 = _interopRequireDefault(_toRGBA);
+            module.exports = exports.default;
+        }, {
+            './toRGBA': 29
+        } ],
+        21: [ function(_dereq_, module, exports) {
+            'use strict';
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(points) {
+                var xMin = 1 / 0, xMax = -(1 / 0), yMin = 1 / 0, yMax = -(1 / 0);
+                return points.forEach(function(p) {
+                    p.x < xMin && (xMin = p.x), p.y < yMin && (yMin = p.y), p.x > xMax && (xMax = p.x), 
+                    p.y > yMax && (yMax = p.y);
+                }), {
+                    x: xMin,
+                    y: yMin,
+                    width: xMax - xMin,
+                    height: yMax - yMin
+                };
+            }, module.exports = exports.default;
+        }, {} ],
+        22: [ function(_dereq_, module, exports) {
+            'use strict';
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
+            }
+            function getColorByPos(pos, colorData, transparentColor) {
+                var x = (0, _clamp2.default)(pos.x, 1, colorData.width - 2), y = (0, _clamp2.default)(pos.y, 1, colorData.height - 2), index = (0 | x) + (0 | y) * colorData.width << 2;
+                index >= colorData.data.length && (index = colorData.data.length - 5);
+                var alpha = colorData.data[index + 3] / 255;
+                return transparentColor && 0 === alpha ? transparentColor : {
+                    r: colorData.data[index],
+                    g: colorData.data[index + 1],
+                    b: colorData.data[index + 2],
+                    a: alpha
+                };
+            }
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = getColorByPos;
+            var _clamp = _dereq_('./clamp'), _clamp2 = _interopRequireDefault(_clamp);
+            module.exports = exports.default;
+        }, {
+            './clamp': 17
+        } ],
+        23: [ function(_dereq_, module, exports) {
+            'use strict';
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            });
+            var _typeof = 'function' == typeof Symbol && 'symbol' == typeof Symbol.iterator ? function(obj) {
+                return typeof obj;
+            } : function(obj) {
+                return obj && 'function' == typeof Symbol && obj.constructor === Symbol ? 'symbol' : typeof obj;
+            };
+            exports.default = function(imageData) {
+                return imageData && 'number' == typeof imageData.width && 'number' == typeof imageData.height && imageData.data && 'number' == typeof imageData.data.length && 'object' === _typeof(imageData.data);
+            }, module.exports = exports.default;
+        }, {} ],
+        24: [ function(_dereq_, module, exports) {
+            'use strict';
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(color) {
+                return 0 === color.a;
+            }, module.exports = exports.default;
+        }, {} ],
+        25: [ function(_dereq_, module, exports) {
+            'use strict';
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(color) {
+                var a = [ color.r, color.g, color.b ].map(function(v) {
+                    return v /= 255, v <= .03928 ? v / 12.92 : Math.pow((v + .055) / 1.055, 2.4);
+                });
+                return .2126 * a[0] + .7152 * a[1] + .0722 * a[2];
+            }, module.exports = exports.default;
+        }, {} ],
+        26: [ function(_dereq_, module, exports) {
+            'use strict';
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
+            }
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(size, options, dpr, format) {
+                var backgroundColor = !(!options || !options.backgroundColor) && options.backgroundColor, canvas = new _canvasBrowserify2.default(size.width * dpr, size.height * dpr, format), ctx = canvas.getContext('2d');
+                return backgroundColor && (ctx.fillStyle = backgroundColor, ctx.fillRect(0, 0, size.width * dpr, size.height * dpr), 
+                ctx.fillStyle = 'transparent'), {
+                    canvas: canvas,
+                    ctx: ctx
+                };
+            };
+            var _canvasBrowserify = _dereq_('canvas-browserify'), _canvasBrowserify2 = _interopRequireDefault(_canvasBrowserify);
+            module.exports = exports.default;
+        }, {
+            'canvas-browserify': 31
+        } ],
+        27: [ function(_dereq_, module, exports) {
+            'use strict';
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(polygon) {
+                return {
+                    x: .33333 * (polygon.a.x + polygon.b.x + polygon.c.x),
+                    y: .33333 * (polygon.a.y + polygon.b.y + polygon.c.y)
+                };
+            }, module.exports = exports.default;
+        }, {} ],
+        28: [ function(_dereq_, module, exports) {
+            'use strict';
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
+            }
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = function(color) {
+                var size = 1, ctx = (0, _makeCanvasAndContext2.default)({
+                    width: size,
+                    height: size
+                }, {}, 1, !0).ctx;
+                ctx.fillStyle = color, ctx.fillRect(0, 0, size, size);
+                var data = ctx.getImageData(0, 0, size, size).data;
+                return {
+                    r: data[0],
+                    g: data[1],
+                    b: data[2],
+                    a: data[3] / 255
+                };
+            };
+            var _makeCanvasAndContext = _dereq_('./makeCanvasAndContext'), _makeCanvasAndContext2 = _interopRequireDefault(_makeCanvasAndContext);
+            module.exports = exports.default;
+        }, {
+            './makeCanvasAndContext': 26
+        } ],
+        29: [ function(_dereq_, module, exports) {
+            'use strict';
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            });
+            var _extends = Object.assign || function(target) {
+                for (var i = 1; i < arguments.length; i++) {
+                    var source = arguments[i];
+                    for (var key in source) {
+                        Object.prototype.hasOwnProperty.call(source, key) && (target[key] = source[key]);
+                    }
+                }
+                return target;
+            };
+            exports.default = function(colorObj) {
+                var c = _extends({
+                    a: 1
+                }, colorObj);
+                return 'rgba(' + c.r + ', ' + c.g + ', ' + c.b + ', ' + c.a + ')';
+            }, module.exports = exports.default;
+        }, {} ],
+        30: [ function(_dereq_, module, exports) {
+            'use strict';
+            function _interopRequireDefault(obj) {
+                return obj && obj.__esModule ? obj : {
+                    default: obj
+                };
+            }
+            function worker(self) {
+                self.addEventListener('message', function(msg) {
+                    if (msg.data.imageData && msg.data.params) {
+                        try {
+                            var imageData = msg.data.imageData;
+                            'undefined' == typeof imageData.width && 'number' == typeof msg.data.imageDataWidth && (imageData.width = msg.data.imageDataWidth), 
+                            'undefined' == typeof imageData.height && 'number' == typeof msg.data.imageDataHeight && (imageData.height = msg.data.imageDataHeight);
+                            var polygons = (0, _imageDataToPolygons2.default)(msg.data.imageData, msg.data.params);
+                            self.postMessage({
+                                polygonJSONStr: JSON.stringify(polygons)
+                            });
+                        } catch (err) {
+                            self.postMessage({
+                                err: err.message || err
+                            });
+                        }
+                    } else {
+                        msg.data.imageData ? self.postMessage({
+                            err: 'Parameters are missing.'
+                        }) : self.postMessage({
+                            err: 'ImageData is missing.'
+                        });
+                    }
+                    self.close();
+                });
+            }
+            Object.defineProperty(exports, '__esModule', {
+                value: !0
+            }), exports.default = worker;
+            var _imageDataToPolygons = _dereq_('../polygons/imageDataToPolygons'), _imageDataToPolygons2 = _interopRequireDefault(_imageDataToPolygons);
+            module.exports = exports.default;
+        }, {
+            '../polygons/imageDataToPolygons': 16
+        } ],
+        31: [ function(_dereq_, module, exports) {
             var Canvas = module.exports = function Canvas(w, h) {
                 var canvas = document.createElement('canvas');
                 canvas.width = w || 300;
@@ -416,7 +975,7 @@
                 return img;
             };
         }, {} ],
-        19: [ function(_dereq_, module, exports) {
+        32: [ function(_dereq_, module, exports) {
             function Triangle(a, b, c) {
                 this.a = a;
                 this.b = b;
@@ -536,7 +1095,98 @@
                 };
             }
         }, {} ],
-        20: [ function(_dereq_, module, exports) {
+        33: [ function(_dereq_, module, exports) {
+            (function(root) {
+                'use strict';
+                function Sobel(imageData) {
+                    if (!(this instanceof Sobel)) {
+                        return new Sobel(imageData);
+                    }
+                    var width = imageData.width;
+                    var height = imageData.height;
+                    var kernelX = [ [ -1, 0, 1 ], [ -2, 0, 2 ], [ -1, 0, 1 ] ];
+                    var kernelY = [ [ -1, -2, -1 ], [ 0, 0, 0 ], [ 1, 2, 1 ] ];
+                    var sobelData = [];
+                    var grayscaleData = [];
+                    function bindPixelAt(data) {
+                        return function(x, y, i) {
+                            i = i || 0;
+                            return data[(width * y + x) * 4 + i];
+                        };
+                    }
+                    var data = imageData.data;
+                    var pixelAt = bindPixelAt(data);
+                    var x, y;
+                    for (y = 0; y < height; y++) {
+                        for (x = 0; x < width; x++) {
+                            var r = pixelAt(x, y, 0);
+                            var g = pixelAt(x, y, 1);
+                            var b = pixelAt(x, y, 2);
+                            var avg = (r + g + b) / 3;
+                            grayscaleData.push(avg, avg, avg, 255);
+                        }
+                    }
+                    pixelAt = bindPixelAt(grayscaleData);
+                    for (y = 0; y < height; y++) {
+                        for (x = 0; x < width; x++) {
+                            var pixelX = kernelX[0][0] * pixelAt(x - 1, y - 1) + kernelX[0][1] * pixelAt(x, y - 1) + kernelX[0][2] * pixelAt(x + 1, y - 1) + kernelX[1][0] * pixelAt(x - 1, y) + kernelX[1][1] * pixelAt(x, y) + kernelX[1][2] * pixelAt(x + 1, y) + kernelX[2][0] * pixelAt(x - 1, y + 1) + kernelX[2][1] * pixelAt(x, y + 1) + kernelX[2][2] * pixelAt(x + 1, y + 1);
+                            var pixelY = kernelY[0][0] * pixelAt(x - 1, y - 1) + kernelY[0][1] * pixelAt(x, y - 1) + kernelY[0][2] * pixelAt(x + 1, y - 1) + kernelY[1][0] * pixelAt(x - 1, y) + kernelY[1][1] * pixelAt(x, y) + kernelY[1][2] * pixelAt(x + 1, y) + kernelY[2][0] * pixelAt(x - 1, y + 1) + kernelY[2][1] * pixelAt(x, y + 1) + kernelY[2][2] * pixelAt(x + 1, y + 1);
+                            var magnitude = Math.sqrt(pixelX * pixelX + pixelY * pixelY) >>> 0;
+                            sobelData.push(magnitude, magnitude, magnitude, 255);
+                        }
+                    }
+                    var clampedArray = sobelData;
+                    if (typeof Uint8ClampedArray === 'function') {
+                        clampedArray = new Uint8ClampedArray(sobelData);
+                    }
+                    clampedArray.toImageData = function() {
+                        return Sobel.toImageData(clampedArray, width, height);
+                    };
+                    return clampedArray;
+                }
+                Sobel.toImageData = function toImageData(data, width, height) {
+                    if (typeof ImageData === 'function' && Object.prototype.toString.call(data) === '[object Uint16Array]') {
+                        return new ImageData(data, width, height);
+                    } else {
+                        if (typeof window === 'object' && typeof window.document === 'object') {
+                            var canvas = document.createElement('canvas');
+                            if (typeof canvas.getContext === 'function') {
+                                var context = canvas.getContext('2d');
+                                var imageData = context.createImageData(width, height);
+                                imageData.data.set(data);
+                                return imageData;
+                            } else {
+                                return new FakeImageData(data, width, height);
+                            }
+                        } else {
+                            return new FakeImageData(data, width, height);
+                        }
+                    }
+                };
+                function FakeImageData(data, width, height) {
+                    return {
+                        width: width,
+                        height: height,
+                        data: data
+                    };
+                }
+                if (typeof exports !== 'undefined') {
+                    if (typeof module !== 'undefined' && module.exports) {
+                        exports = module.exports = Sobel;
+                    }
+                    exports.Sobel = Sobel;
+                } else {
+                    if (typeof define === 'function' && define.amd) {
+                        define([], function() {
+                            return Sobel;
+                        });
+                    } else {
+                        root.Sobel = Sobel;
+                    }
+                }
+            })(this);
+        }, {} ],
+        34: [ function(_dereq_, module, exports) {
             var mul_table = [ 512, 512, 456, 512, 328, 456, 335, 512, 405, 328, 271, 456, 388, 335, 292, 512, 454, 405, 364, 328, 298, 271, 496, 456, 420, 388, 360, 335, 312, 292, 273, 512, 482, 454, 428, 405, 383, 364, 345, 328, 312, 298, 284, 271, 259, 496, 475, 456, 437, 420, 404, 388, 374, 360, 347, 335, 323, 312, 302, 292, 282, 273, 265, 512, 497, 482, 468, 454, 441, 428, 417, 405, 394, 383, 373, 364, 354, 345, 337, 328, 320, 312, 305, 298, 291, 284, 278, 271, 265, 259, 507, 496, 485, 475, 465, 456, 446, 437, 428, 420, 412, 404, 396, 388, 381, 374, 367, 360, 354, 347, 341, 335, 329, 323, 318, 312, 307, 302, 297, 292, 287, 282, 278, 273, 269, 265, 261, 512, 505, 497, 489, 482, 475, 468, 461, 454, 447, 441, 435, 428, 422, 417, 411, 405, 399, 394, 389, 383, 378, 373, 368, 364, 359, 354, 350, 345, 341, 337, 332, 328, 324, 320, 316, 312, 309, 305, 301, 298, 294, 291, 287, 284, 281, 278, 274, 271, 268, 265, 262, 259, 257, 507, 501, 496, 491, 485, 480, 475, 470, 465, 460, 456, 451, 446, 442, 437, 433, 428, 424, 420, 416, 412, 408, 404, 400, 396, 392, 388, 385, 381, 377, 374, 370, 367, 363, 360, 357, 354, 350, 347, 344, 341, 338, 335, 332, 329, 326, 323, 320, 318, 315, 312, 310, 307, 304, 302, 299, 297, 294, 292, 289, 287, 285, 282, 280, 278, 275, 273, 271, 269, 267, 265, 263, 261, 259 ];
             var shg_table = [ 9, 11, 12, 13, 13, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 17, 17, 17, 17, 17, 17, 17, 18, 18, 18, 18, 18, 18, 18, 18, 18, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24 ];
             function processImage(img, canvas, radius, blurAlphaChannel) {
@@ -586,17 +1236,10 @@
                     try {
                         imageData = context.getImageData(top_x, top_y, width, height);
                     } catch (e) {
-                        try {
-                            netscape.security.PrivilegeManager.enablePrivilege('UniversalBrowserRead');
-                            imageData = context.getImageData(top_x, top_y, width, height);
-                        } catch (e) {
-                            alert('Cannot access local image');
-                            throw new Error('unable to access local image data: ' + e);
-                            return;
-                        }
+                        throw new Error('unable to access local image data: ' + e);
+                        return;
                     }
                 } catch (e) {
-                    alert('Cannot access image');
                     throw new Error('unable to access image data: ' + e);
                 }
                 return imageData;
@@ -946,6 +1589,51 @@
                 imageDataRGBA: processImageDataRGBA,
                 imageDataRGB: processImageDataRGB
             };
+        }, {} ],
+        35: [ function(_dereq_, module, exports) {
+            var bundleFn = arguments[3];
+            var sources = arguments[4];
+            var cache = arguments[5];
+            var stringify = JSON.stringify;
+            module.exports = function(fn, options) {
+                var wkey;
+                var cacheKeys = Object.keys(cache);
+                for (var i = 0, l = cacheKeys.length; i < l; i++) {
+                    var key = cacheKeys[i];
+                    var exp = cache[key].exports;
+                    if (exp === fn || exp && exp.default === fn) {
+                        wkey = key;
+                        break;
+                    }
+                }
+                if (!wkey) {
+                    wkey = Math.floor(Math.pow(16, 8) * Math.random()).toString(16);
+                    var wcache = {};
+                    for (var i = 0, l = cacheKeys.length; i < l; i++) {
+                        var key = cacheKeys[i];
+                        wcache[key] = key;
+                    }
+                    sources[wkey] = [ Function([ 'require', 'module', 'exports' ], '(' + fn + ')(self)'), wcache ];
+                }
+                var skey = Math.floor(Math.pow(16, 8) * Math.random()).toString(16);
+                var scache = {};
+                scache[wkey] = wkey;
+                sources[skey] = [ Function([ 'require' ], 'var f = require(' + stringify(wkey) + ');' + '(f.default ? f.default : f)(self);'), scache ];
+                var src = '(' + bundleFn + ')({' + Object.keys(sources).map(function(key) {
+                    return stringify(key) + ':[' + sources[key][0] + ',' + stringify(sources[key][1]) + ']';
+                }).join(',') + '},{},[' + stringify(skey) + '])';
+                var URL = window.URL || window.webkitURL || window.mozURL || window.msURL;
+                var blob = new Blob([ src ], {
+                    type: 'text/javascript'
+                });
+                if (options && options.bare) {
+                    return blob;
+                }
+                var workerUrl = URL.createObjectURL(blob);
+                var worker = new Worker(workerUrl);
+                worker.objectURL = workerUrl;
+                return worker;
+            };
         }, {} ]
-    }, {}, [ 17 ])(17);
+    }, {}, [ 1 ])(1);
 });

--- a/scripts/src/process.js
+++ b/scripts/src/process.js
@@ -59,8 +59,9 @@ define(
 			clearCanvas( canvas, ctx );
 			resizeCanvas( canvas, img, pxratio );
 						
-			triangulated_image_data = triangulate( values ).fromImage( img ).toImageData( { dpr: pxratio } );
-			updateCanvas( ctx, triangulated_image_data );
+			triangulate( values ).fromImage( img ).toImageData( { dpr: pxratio } ).then( function(triangulated_image_data) {
+				updateCanvas( ctx, triangulated_image_data );
+			});
 
 			is_processing = false;
 		}
@@ -90,7 +91,7 @@ define(
 			{
 				var export_data = {
 					png: canvas.toDataURL( 'image/png' ),
-					svg: triangulate( values ).fromImage( image ).toSVG()
+					svg: triangulate( values ).fromImageSync( image ).toSVGSync()
 				};
 
 				callback( export_data );


### PR DESCRIPTION
Update to latest triangulate-image library to get transparency support for free (_and probably a bunch of other stuff you fixed since Jan'2016 - the last time you pulled this lib_)
See: https://github.com/snorpey/triangulate-image/issues/24